### PR TITLE
Add Buffexist to script 

### DIFF
--- a/Razor/Core/Mobile.cs
+++ b/Razor/Core/Mobile.cs
@@ -66,9 +66,9 @@ namespace Assistant
         private bool m_Poisoned;
         private bool m_Blessed;
         private bool m_Warmode;
+        private bool m_Paralyze;
 
         //new
-        private bool m_Unknown;
         private bool m_Unknown2;
         private bool m_Unknown3;
 
@@ -293,11 +293,10 @@ namespace Assistant
             get { return !IsHuman; }
         }
 
-        //new
-        public bool Unknown
+        public bool Paralyze
         {
-            get { return m_Unknown; }
-            set { m_Unknown = value; }
+            get { return m_Paralyze; }
+            set { m_Paralyze = value; }
         }
 
         public bool Unknown2
@@ -544,6 +543,9 @@ namespace Assistant
         {
             int flags = 0x0;
 
+            if (m_Paralyze)
+                flags |= 0x01;
+
             if (m_Female)
                 flags |= 0x02;
 
@@ -559,9 +561,6 @@ namespace Assistant
             if (!m_Visible)
                 flags |= 0x80;
 
-            if (m_Unknown)
-                flags |= 0x01;
-
             if (m_Unknown2)
                 flags |= 0x10;
 
@@ -576,7 +575,7 @@ namespace Assistant
             if (!PacketHandlers.UseNewStatus)
                 m_Poisoned = (flags & 0x04) != 0;
 
-            m_Unknown = (flags & 0x01) != 0; //new
+            m_Paralyze = (flags & 0x01) != 0;
             m_Female = (flags & 0x02) != 0;
             m_Blessed = (flags & 0x08) != 0;
             m_Unknown2 = (flags & 0x10) != 0; //new

--- a/Razor/Scripts/Expressions.cs
+++ b/Razor/Scripts/Expressions.cs
@@ -29,6 +29,9 @@ namespace Assistant.Scripts
 {
     public static class Expressions
     {
+        // Take all list of BuffIcon to string
+        private static readonly string[] buffNames = Enum.GetNames(typeof(BuffIcon));
+
         public static void Register()
         {
             Interpreter.RegisterExpressionHandler("stam", Stam);
@@ -40,7 +43,9 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("mana", Mana);
             Interpreter.RegisterExpressionHandler("maxmana", MaxMana);
             Interpreter.RegisterExpressionHandler("poisoned", Poisoned);
+            Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
             Interpreter.RegisterExpressionHandler("hidden", Hidden);
+            Interpreter.RegisterExpressionHandler("buffexist", BuffExist);
 
             Interpreter.RegisterExpressionHandler("mounted", Mounted);
             Interpreter.RegisterExpressionHandler("rhandempty", RHandEmpty);
@@ -220,9 +225,36 @@ namespace Assistant.Scripts
                    World.Player.Poisoned;
         }
 
+        private static bool Paralyzed(string expression, Variable[] args, bool quiet)
+        {
+            // Simple expresion for Paralyzed
+            if (World.Player == null)
+                return false;
+
+            return World.Player.BuffsDebuffs.Exists(buff => buff.BuffIcon == BuffIcon.Paralyze);
+        }
+
         private static bool Hidden(string expression, Variable[] args, bool quiet)
         {
             return World.Player != null && !World.Player.Visible;
+        }
+
+        private static bool BuffExist(string expression, Variable[] args, bool quiet)
+        {
+            // Complex expression for more types of buff
+            if (args.Length < 1)
+                throw new RunTimeError("Usage: buffexist ('buff name')");
+
+            if (World.Player == null)
+                return false;
+
+            var correctBuffName = Array.Find(buffNames, x => x.ToLower() == args[0].AsString().ToLower());
+            if (string.IsNullOrEmpty(correctBuffName))
+            {
+                throw new RunTimeError("Wrong buff name");
+            }
+
+            return World.Player.BuffsDebuffs.Exists(x => x.BuffIcon == (BuffIcon)Enum.Parse(typeof(BuffIcon), correctBuffName));
         }
 
         private static int Hp(string expression, Variable[] args, bool quiet)

--- a/Razor/Scripts/Expressions.cs
+++ b/Razor/Scripts/Expressions.cs
@@ -29,9 +29,6 @@ namespace Assistant.Scripts
 {
     public static class Expressions
     {
-        // Take all list of BuffIcon to string
-        private static readonly string[] buffNames = Enum.GetNames(typeof(BuffIcon));
-
         public static void Register()
         {
             Interpreter.RegisterExpressionHandler("stam", Stam);
@@ -43,9 +40,7 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("mana", Mana);
             Interpreter.RegisterExpressionHandler("maxmana", MaxMana);
             Interpreter.RegisterExpressionHandler("poisoned", Poisoned);
-            Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
             Interpreter.RegisterExpressionHandler("hidden", Hidden);
-            Interpreter.RegisterExpressionHandler("buffexist", BuffExist);
 
             Interpreter.RegisterExpressionHandler("mounted", Mounted);
             Interpreter.RegisterExpressionHandler("rhandempty", RHandEmpty);
@@ -225,36 +220,9 @@ namespace Assistant.Scripts
                    World.Player.Poisoned;
         }
 
-        private static bool Paralyzed(string expression, Variable[] args, bool quiet)
-        {
-            // Simple expresion for Paralyzed
-            if (World.Player == null)
-                return false;
-
-            return World.Player.BuffsDebuffs.Exists(buff => buff.BuffIcon == BuffIcon.Paralyze);
-        }
-
         private static bool Hidden(string expression, Variable[] args, bool quiet)
         {
             return World.Player != null && !World.Player.Visible;
-        }
-
-        private static bool BuffExist(string expression, Variable[] args, bool quiet)
-        {
-            // Complex expression for more types of buff
-            if (args.Length < 1)
-                throw new RunTimeError("Usage: buffexist ('buff name')");
-
-            if (World.Player == null)
-                return false;
-
-            var correctBuffName = Array.Find(buffNames, x => x.ToLower() == args[0].AsString().ToLower());
-            if (string.IsNullOrEmpty(correctBuffName))
-            {
-                throw new RunTimeError("Wrong buff name");
-            }
-
-            return World.Player.BuffsDebuffs.Exists(x => x.BuffIcon == (BuffIcon)Enum.Parse(typeof(BuffIcon), correctBuffName));
         }
 
         private static int Hp(string expression, Variable[] args, bool quiet)

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -68,6 +68,7 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("hue", Hue);
 
             Interpreter.RegisterExpressionHandler("buffexist", BuffExist);
+            Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
         }
 
         private static bool PopList(string command, Variable[] args, bool quiet, bool force)
@@ -349,6 +350,13 @@ namespace Assistant.Scripts
                 return 0;
 
             return item.Hue;
+        }
+
+        private static bool Paralyzed(string expression, Variable[] args, bool quiet)
+        {
+            if (World.Player == null)
+                return false;
+            return World.Player.Paralyze;
         }
 
         private static bool BuffExist(string expression, Variable[] args, bool quiet)

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -19,20 +19,17 @@
 #endregion
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Windows.Forms;
 using Assistant.Core;
-using Assistant.HotKeys;
 using Assistant.Scripts.Engine;
-using Assistant.Scripts.Helpers;
 
 namespace Assistant.Scripts
 {
     public static class Outlands
     {
+        // Take all list of BuffIcon to string
+        private static readonly string[] buffNames = Enum.GetNames(typeof(BuffIcon));
+
         public static void Register()
         {
             // Lists
@@ -60,6 +57,10 @@ namespace Assistant.Scripts
 
             Interpreter.RegisterExpressionHandler("followers", Followers);
             Interpreter.RegisterExpressionHandler("hue", Hue);
+
+
+            Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
+            Interpreter.RegisterExpressionHandler("buffexist", BuffExist);
         }
 
         private static bool PopList(string command, Variable[] args, bool quiet, bool force)
@@ -341,6 +342,33 @@ namespace Assistant.Scripts
                 return 0;
 
             return item.Hue;
+        }
+
+        private static bool Paralyzed(string expression, Variable[] args, bool quiet)
+        {
+            // Simple expresion for Paralyzed
+            if (World.Player == null)
+                return false;
+
+            return World.Player.BuffsDebuffs.Exists(buff => buff.BuffIcon == BuffIcon.Paralyze);
+        }
+
+        private static bool BuffExist(string expression, Variable[] args, bool quiet)
+        {
+            // Complex expression for more types of buff
+            if (args.Length < 1)
+                throw new RunTimeError("Usage: buffexist ('buff name')");
+
+            if (World.Player == null)
+                return false;
+
+            var correctBuffName = Array.Find(buffNames, x => x.ToLower() == args[0].AsString().ToLower());
+            if (string.IsNullOrEmpty(correctBuffName))
+            {
+                throw new RunTimeError("Wrong buff name");
+            }
+
+            return World.Player.BuffsDebuffs.Exists(x => x.BuffIcon == (BuffIcon)Enum.Parse(typeof(BuffIcon), correctBuffName));
         }
     }
 }

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -19,6 +19,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Assistant.Core;
 using Assistant.Scripts.Engine;
@@ -27,8 +28,16 @@ namespace Assistant.Scripts
 {
     public static class Outlands
     {
-        // Take all list of BuffIcon to string
-        private static readonly string[] buffNames = Enum.GetNames(typeof(BuffIcon));
+        // Map string passed to Razor with BuffIcon
+        private static readonly Dictionary<string, BuffIcon> buffNameMap = new Dictionary<string, BuffIcon>()
+        {
+            { "paralyze", BuffIcon.Paralyze },
+            { "meditation", BuffIcon.ActiveMeditation },
+            { "invisibility", BuffIcon.HidingAndOrStealth },
+            { "agility", BuffIcon.Agility },
+            { "strength", BuffIcon.Strength },
+            { "magicreflection", BuffIcon.MagicReflection }
+        };
 
         public static void Register()
         {
@@ -58,8 +67,6 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("followers", Followers);
             Interpreter.RegisterExpressionHandler("hue", Hue);
 
-
-            Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
             Interpreter.RegisterExpressionHandler("buffexist", BuffExist);
         }
 
@@ -344,15 +351,6 @@ namespace Assistant.Scripts
             return item.Hue;
         }
 
-        private static bool Paralyzed(string expression, Variable[] args, bool quiet)
-        {
-            // Simple expresion for Paralyzed
-            if (World.Player == null)
-                return false;
-
-            return World.Player.BuffsDebuffs.Exists(buff => buff.BuffIcon == BuffIcon.Paralyze);
-        }
-
         private static bool BuffExist(string expression, Variable[] args, bool quiet)
         {
             // Complex expression for more types of buff
@@ -362,13 +360,12 @@ namespace Assistant.Scripts
             if (World.Player == null)
                 return false;
 
-            var correctBuffName = Array.Find(buffNames, x => x.ToLower() == args[0].AsString().ToLower());
-            if (string.IsNullOrEmpty(correctBuffName))
-            {
+            if(!buffNameMap.TryGetValue(args[0].AsString().ToLower(), out var passedBuff))
+            { 
                 throw new RunTimeError("Wrong buff name");
             }
 
-            return World.Player.BuffsDebuffs.Exists(x => x.BuffIcon == (BuffIcon)Enum.Parse(typeof(BuffIcon), correctBuffName));
+            return World.Player.BuffsDebuffs.Exists(x => x.BuffIcon == passedBuff);
         }
     }
 }

--- a/Razor/Scripts/ScriptManager.cs
+++ b/Razor/Scripts/ScriptManager.cs
@@ -934,6 +934,18 @@ namespace Assistant.Scripts
                 "unsetvar myvar\n");
             descriptionCommands.Add("unsetvar", tooltip);
 
+            tooltip = new ToolTipDescriptions("buffexist",
+                new[] { "buffexist ('buffname')" }, "N/A",
+                "TODO: put here awsome desc",
+                "buffexist paralyze\n");
+            descriptionCommands.Add("buffexist", tooltip);
+
+            tooltip = new ToolTipDescriptions("paralyzed",
+                new[] { "paralyzed" }, "N/A",
+                "TODO: put here awsome desc",
+                "paralyzed\n");
+            descriptionCommands.Add("paralyzed", tooltip);
+
             #endregion
 
             if (!Config.GetBool("DisableScriptTooltips"))


### PR DESCRIPTION
Just to show what i mean:
- paralyzed expression - simple take only paralyzed
- buffexist - take whole BuffIcon and look for it . I notice that Poision not work that way. We can also introduce some lookuptable to specified with buff can be handle that way (or rename it like in ActiveMedidation one) 