### PR TITLE
Fix error where is no settings file

### DIFF
--- a/Razor/UI/Config.cs
+++ b/Razor/UI/Config.cs
@@ -749,7 +749,6 @@ namespace Assistant
             { }
             finally
             {
-                SaveAppSettings();
             }
         }
 


### PR DESCRIPTION
When user run ClassicUO with Razor and don't have settings.csv file they got error.

-- File in use
