### PR TITLE
Fix while as

### DIFF
--- a/Razor/Scripts/Engine/Interpreter.cs
+++ b/Razor/Scripts/Engine/Interpreter.cs
@@ -1058,8 +1058,9 @@ namespace Assistant.Scripts.Engine
                         var arg = Interpreter.GetVariable(node.Lexeme);
                         if (arg != null)
                         {
-                            // TODO: Should really look at the type of arg here
-                            val = arg.AsString();
+                            // If we know that this is variable, we should only put alias
+                            // as value instead of really serial no to prevent infinity look in AsString()
+                            val = node.Lexeme;
                             node = node.Next();
                             break;
                         }

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -65,6 +65,7 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
             Interpreter.RegisterExpressionHandler("blessed", Blessed);
             Interpreter.RegisterExpressionHandler("warmode", InWarmode);
+            Interpreter.RegisterExpressionHandler("noto", Notoriety);
         }
 
         private static bool PopList(string command, Variable[] args, bool quiet, bool force)
@@ -435,6 +436,42 @@ namespace Assistant.Scripts
                 return false;
 
             return World.Player.Warmode;
+        }
+
+        /**
+            * Notoriety
+            0x1: Innocent (Blue)
+            0x2: Friend (Green)
+            0x3: Gray (Gray - Animal)
+            0x4: Criminal (Gray)
+            0x5: Enemy (Orange)
+            0x6: Murderer (Red)
+            0x7: Invulnerable (Yellow)
+         */
+        private static Dictionary<byte, string> _notorietyMap = new Dictionary<byte, string>
+        {
+            { 1, "innocent" },
+            { 2, "green" },
+            { 3, "gray" },
+            { 4, "criminal" },
+            { 5, "enemy" },
+            { 6, "murderer" },
+            { 7, "invulnerable" }
+        };
+
+        private static string Notoriety(string expression, Variable[] args, bool quiet)
+        {
+            if (args.Length != 1)
+                throw new RunTimeError("Usage: noto (serial)");
+
+            var target = args[0].AsSerial();
+
+            var m = World.FindMobile(target);
+
+            if (m == null)
+                throw new RunTimeError("Can't find mobile with given serial");
+
+            return _notorietyMap[m.Notoriety];
         }
     }
 }


### PR DESCRIPTION
When user put 
```
while findtype apple%s% as apple
  dclick apple
endwhile
```
it will shrow StackOverflow since behind the scene we create two variables - one with {apple : serial_no} and {serial_no: serial_no}
after that when code mees serial_no.AsString() it will first stack with GetVariable().

We need to pass to BinaryExpression node.Lexem instead of serial to prevent creating multivariables

Since i'm realy bad with explaining staff:
- Interpreter line 1062 it will pass {serial : serial} to it, and them
- Interpreter line 207 it will reciew serial and since serial is as variable it will infinity look for value