### PR TITLE
fix several gumps bugs

### DIFF
--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -2560,6 +2560,9 @@ namespace Assistant
 
                 World.Player.CurrentGumpStrings.AddRange(gumpStrings);
 
+                if (World.Player.GumpList.ContainsKey(World.Player.CurrentGumpI))
+                    World.Player.GumpList.Remove(World.Player.CurrentGumpI);
+
                 World.Player.GumpList.Add(World.Player.CurrentGumpI, new PlayerData.GumpInfo(World.Player.CurrentGumpS, World.Player.CurrentGumpI, gumpStrings));
                 World.Player.CurrentGumpRawData = layout; // Get raw data of current gump
             }

--- a/Razor/Scripts/Commands.cs
+++ b/Razor/Scripts/Commands.cs
@@ -275,19 +275,10 @@ namespace Assistant.Scripts
 
         private static bool WaitForGump(string command, Variable[] args, bool quiet, bool force)
         {
-            if (args.Length < 1)
-            {
-                throw new RunTimeError("Usage: waitforgump (gumpId/'any') [timeout]");
-            }
-
             uint gumpId = 0;
             bool strict = false;
 
-            if (args[0].AsString().IndexOf("any", StringComparison.InvariantCultureIgnoreCase) != -1)
-            {
-                strict = false;
-            }
-            else
+            if (args.Length > 0)
             {
                 gumpId = Utility.ToUInt32(args[0].AsString(), 0);
 
@@ -1032,10 +1023,10 @@ namespace Assistant.Scripts
 
             var gumpS = World.Player.GumpList[gumpId].GumpSerial;
 
-            Client.Instance.SendToClient(new CloseGump(gumpId));
             Client.Instance.SendToServer(new GumpResponse(gumpS, gumpId,
                 buttonId, new int[] { }, new GumpTextEntry[] { }));
 
+            Client.Instance.SendToClient(new CloseGump(gumpId));
             World.Player.HasGump = false;
 
             return true;

--- a/Razor/Scripts/Helpers/CommandHelper.cs
+++ b/Razor/Scripts/Helpers/CommandHelper.cs
@@ -221,6 +221,26 @@ namespace Assistant.Scripts.Helpers
         }
 
         /// <summary>
+        /// Check if passed string is number and assign out variable to that number
+        /// </summary>
+        /// <param name="sNumber">String with number</param>
+        public static uint IsUNumberOrAny(string sNumber)
+        {
+            var num = Utility.ToUInt32(sNumber, 0);
+            if (num != 0)
+            {
+                return num;
+            }
+
+            if (sNumber.ToLower() != "any")
+            {
+                throw new RunTimeError("Wrong parameter");
+            }
+
+            return UInt32.MaxValue;
+        }
+
+        /// <summary>
         /// Deconstruct arguments
         /// </summary>
         /// <param name="args">Array with arguments</param>

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -77,7 +77,7 @@ namespace Assistant.Scripts
             Interpreter.RegisterExpressionHandler("targetexists", TargetExists);
 
             // Gump
-            Interpreter.RegisterExpressionHandler("gumpexist", GumpExist);
+            Interpreter.RegisterExpressionHandler("gumpexists", GumpExists);
             Interpreter.RegisterExpressionHandler("ingump", InGump);
         }
 
@@ -644,7 +644,7 @@ namespace Assistant.Scripts
 
             if (args.Length > 0)
             {
-                if (!_targetMap.TryGetValue(args[0].AsString(), out type))
+                if (!_targetMap.TryGetValue(args[0].AsString().ToLower(), out type))
                 {
                     throw new RunTimeError("Invalid target type");
                 }
@@ -666,19 +666,19 @@ namespace Assistant.Scripts
         /// <param name="args">Args - should contain gump id or any</param>
         /// <param name="quiet">Not used</param>
         /// <returns></returns>
-        private static bool GumpExist(string expression, Variable[] args, bool quiet)
+        private static bool GumpExists(string expression, Variable[] args, bool quiet)
         {
             if (args.Length != 1)
-                throw new RunTimeError("Usage: gumpexist (gumpId/'any')");
+                throw new RunTimeError("Usage: gumpexists (gumpId/'any')");
 
-            var gumpId = CommandHelper.IsNumberOrAny(args[0].AsString());
+            var gumpId = CommandHelper.IsUNumberOrAny(args[0].AsString());
 
             // If any just return if user have gump
-            if (gumpId == -1)
+            if (gumpId == uint.MaxValue)
                 return World.Player.GumpList.Count > 0;
 
             // If gumpId specific check for it
-            return World.Player.GumpList.ContainsKey((uint)gumpId);
+            return World.Player.GumpList.ContainsKey(gumpId);
         }
 
         /// <summary>


### PR DESCRIPTION
- gumpresponse - problem here was because server send res gump twice, not once. So i send response with old gump serial. Fixed - testing it right now
- waitforgump - i didn't meet any problems (only that you have to add any to it, I remove that restriction, and now gumpId/any is not mandatory)
- gumpexist - Outlands have long gump ids, longet then int. I  used uint and it work now
- targetexist - fixed