### PR TITLE
Remove restriction on item id above 0x4000

### DIFF
--- a/Razor/Agents/RestockAgent.cs
+++ b/Razor/Agents/RestockAgent.cs
@@ -390,7 +390,7 @@ namespace Assistant.Agents
                 gfx = item.ItemID;
             }
 
-            if (gfx == 0 || gfx >= 0x4000)
+            if (gfx == 0)
             {
                 return;
             }
@@ -420,7 +420,7 @@ namespace Assistant.Agents
             }
 
             m_Items.Add(item);
-            m_SubList.Items.Add(item);
+            Engine.MainWindow.SafeAction(m => m_SubList.Items.Add(item));
 
             World.Player?.SendMessage(MsgLevel.Force, LocString.ItemAdded);
         }


### PR DESCRIPTION
Some item's if far above 0x4000 so there was not possible to add it to restock item
