### PR TITLE
Fix getLabel infinity loop & rename `blessed`

### DIFF
--- a/Razor/Core/MessageManager.cs
+++ b/Razor/Core/MessageManager.cs
@@ -31,6 +31,8 @@ namespace Assistant.Core
         public static Action<Packet, PacketHandlerEventArgs, Serial, ushort, MessageType, ushort, ushort, string, string, string> OnSystemMessage;
         public static Action<Packet, PacketHandlerEventArgs, Serial, ushort, MessageType, ushort, ushort, string, string, string> OnMobileMessage;
 
+        public static bool GetLabelCommand = false;
+
         public static void Initialize()
         {
             OnMobileMessage += HandleMobileMessage;
@@ -68,7 +70,10 @@ namespace Assistant.Core
 
                     if (source.IsMobile && source != World.Player.Serial)
                     {
-                        OnMobileMessage?.Invoke(p, args, source, graphic, type, hue, font, lang, sourceName, text);
+                        if(GetLabelCommand)
+                            OnLabelMessage?.Invoke(p, args, source, graphic, type, hue, font, lang, sourceName, text);
+                        else
+                            OnMobileMessage?.Invoke(p, args, source, graphic, type, hue, font, lang, sourceName, text);
                     }
                     break;
             }

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -216,7 +216,10 @@ namespace Assistant.Scripts
                     _getLabelState = GetLabelState.WAITING_FOR_FIRST_LABEL;
                     Interpreter.Timeout(2000, () =>
                     {
-                        _getLabelState = GetLabelState.NONE; 
+                        _onLabelMessage = null;
+                        MessageManager.OnLabelMessage -= _onLabelMessage;
+                        _getLabelState = GetLabelState.NONE;
+                        MessageManager.GetLabelCommand = false;
                         return true;
                     });
 
@@ -225,6 +228,11 @@ namespace Assistant.Scripts
 
                     // Capture all message responses
                     StringBuilder label = new StringBuilder();
+                    
+                    // Some messages from Outlands server are send in sequence of LabelType and RegularType
+                    // so we want to invoke that _onLabelMessage in both cases with delays
+                    MessageManager.GetLabelCommand = true;
+
                     _onLabelMessage = (p, a, source, graphic, type, hue, font, lang, sourceName, text) =>
                     {
                         if (source != serial)
@@ -241,7 +249,7 @@ namespace Assistant.Scripts
 
                         label.AppendLine(text);
 
-                        Interpreter.SetVariable(name, label.ToString(), false);
+                        Interpreter.SetVariable(name, label.ToString());
                     };
 
                     MessageManager.OnLabelMessage += _onLabelMessage;
@@ -253,6 +261,7 @@ namespace Assistant.Scripts
                     MessageManager.OnLabelMessage -= _onLabelMessage;
                     _onLabelMessage = null;
                     _getLabelState = GetLabelState.NONE;
+                    MessageManager.GetLabelCommand = false;
                     return true;
             }
 

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -77,7 +77,7 @@ namespace Assistant.Scripts
 
             // Mobile flags
             Interpreter.RegisterExpressionHandler("paralyzed", Paralyzed);
-            Interpreter.RegisterExpressionHandler("blessed", Blessed);
+            Interpreter.RegisterExpressionHandler("invul", Blessed);
             Interpreter.RegisterExpressionHandler("warmode", InWarmode);
             Interpreter.RegisterExpressionHandler("noto", Notoriety);
             Interpreter.RegisterExpressionHandler("dead", Dead);
@@ -214,7 +214,11 @@ namespace Assistant.Scripts
             {
                 case GetLabelState.NONE:
                     _getLabelState = GetLabelState.WAITING_FOR_FIRST_LABEL;
-                    Interpreter.Timeout(2000, () => { return true; });
+                    Interpreter.Timeout(2000, () =>
+                    {
+                        _getLabelState = GetLabelState.NONE; 
+                        return true;
+                    });
 
                     // Single click the object
                     Client.Instance.SendToServer(new SingleClick((Serial)args[0].AsSerial()));


### PR DESCRIPTION
- Rename expression blessed with invul - Blessed is used to check if item is blessed in cale `if blessed in myVar`
- change state of GetLableState to NONE after timeout
- fix multiline label like 
```
(bounded)
a packet llama
``` 