### PR TITLE
Fixed exception where enumerator was modified while enumerating, leading to InvalidOperationException

### DIFF
--- a/Razor/Scripts/ScriptVariables.cs
+++ b/Razor/Scripts/ScriptVariables.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 using Assistant.Scripts.Engine;
 
@@ -79,7 +80,8 @@ namespace Assistant.Scripts
 
         public static void ClearAll()
         {
-            foreach (var kv in _variables)
+            var varList = _variables.ToList();
+            foreach (var kv in varList)
             {
                 UnregisterVariable(kv.Key);
             }


### PR DESCRIPTION
Bug reproduction:

1. Create a fresh ClassicUO/Razor install
2. Use the default profile
3. Add one or more script variables

Reason for crash/exception:

When loading the config, razor would create a default profile, razor would load the variables and then call ScriptVariables.ClearAll(). This would lead to the ClearAll method iterating over _variables, calling UnregisterVariable(), which in turn would remove the variable from the _variables dictionary. This then lead to an InvalidOperationException.

This bug could be the reason so many people have experienced problems with razor not starting anymore after some time of using it when they first added a script variable.

![image](https://user-images.githubusercontent.com/59250627/140568183-1503d8a6-5287-46c1-9132-476e852abbcb.png)
