### PR TITLE
error

### DIFF
--- a/FastColoredTextBox/SyntaxHighlighter.cs
+++ b/FastColoredTextBox/SyntaxHighlighter.cs
@@ -355,12 +355,12 @@ namespace FastColoredTextBoxNS
             RazorNumberRegex = new Regex(@"\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b", RegexCompiledOption);
             RazorKeywordRegex =
                 new Regex(
-                    @"\b(if|elseif|else|endif|while|endwhile|for|endfor|break|continue|not|and|or|stop|replay|loop)\b",
+                    @"\b(if|elseif|else|endif|while|endwhile|for|foreach|endfor|break|continue|not|and|or|stop|replay|loop)\b",
                     RegexCompiledOption);
 
             RazorCommandRegex =
                 new Regex(
-                    @"\b(attack|cast|dress|undress|dressconfig|target|targettype|targetloc|targetrelloc|dress|drop|waitfortarget|wft|dclick|dclicktype|dclickvar|usetype|useobject|droprelloc|lift|lifttype|waitforgump|gumpresponse|gumpclose|menu|menuresponse|waitformenu|promptresponse|waitforprompt|hotkey|say|msg|overhead|sysmsg|wait|pause|waitforstat|setability|setlasttarget|lasttarget|setvar|skill|useskill|walk|script|useonce|organizer|organize|org|restock|scav|scavenger|potion|clearsysmsg|clearjournal|whisper|yell|guild|alliance|emote|waitforsysmsg|wfsysmsg|clearall|virtue|rename|setskill|ignore|clearignore|poplist|pushlist|removelist|createlist|clearlist|atlist|settimer|removetimer|createtimer|settimer|removetimer|getlabel|unsetvar)\b",
+                    @"\b(attack|cast|dress|undress|dressconfig|target|targettype|targetloc|targetrelloc|dress|drop|waitfortarget|wft|dclick|dclicktype|dclickvar|usetype|useobject|droprelloc|lift|lifttype|waitforgump|gumpresponse|gumpclose|menu|menuresponse|waitformenu|promptresponse|waitforprompt|hotkey|say|msg|overhead|sysmsg|wait|pause|waitforstat|setability|setlasttarget|lasttarget|setvar|skill|useskill|walk|script|useonce|organizer|organize|org|restock|scav|scavenger|potion|clearsysmsg|clearjournal|whisper|yell|guild|alliance|emote|waitforsysmsg|wfsysmsg|clearall|virtue|rename|setskill|ignore|clearignore|pushlist|removelist|createlist|clearlist|settimer|removetimer|createtimer|settimer|removetimer|getlabel|unsetvar)\b",
                     RegexCompiledOption);
 
              RazorLayerRegex =
@@ -370,7 +370,7 @@ namespace FastColoredTextBoxNS
 
             RazorExpressionRegex =
                 new Regex(
-                    @"\b(queued|position|insysmsg|insysmessage|findtype|findbuff|finddebuff|stam|maxstam|hp|maxhp|maxhits|hits|mana|maxmana|str|dex|int|poisoned|hidden|mounted|rhandempty|lhandempty|skill|count|counter|weight|dead|closest|close|rand|random|next|prev|previous|human|humanoid|monster|findlayer|dead|find|counttype|listexists|list|inlist|timer|timerexists|followers|hue|name|maxweight|diffweight|diffhits|diffstam|diffmana|paralyzed|invul|noto|dead|gumpexists|ingump|targetexists|counttype)\b",
+                    @"\b(queued|position|insysmsg|insysmessage|findtype|findbuff|finddebuff|stam|maxstam|hp|maxhp|maxhits|hits|mana|maxmana|str|dex|int|poisoned|hidden|mounted|rhandempty|lhandempty|skill|count|counter|weight|dead|closest|close|rand|random|next|prev|previous|human|humanoid|monster|findlayer|dead|find|counttype|listexists|list|inlist|atlist|poplist|timer|timerexists|followers|hue|name|maxweight|diffweight|diffhits|diffstam|diffmana|paralyzed|invul|noto|dead|gumpexists|ingump|targetexists|counttype)\b",
                     RegexCompiledOption);
         }
 

--- a/FastColoredTextBox/SyntaxHighlighter.cs
+++ b/FastColoredTextBox/SyntaxHighlighter.cs
@@ -360,7 +360,7 @@ namespace FastColoredTextBoxNS
 
             RazorCommandRegex =
                 new Regex(
-                    @"\b(attack|cast|dress|undress|dressconfig|target|targettype|targetloc|targetrelloc|dress|drop|waitfortarget|wft|dclick|dclicktype|dclickvar|usetype|useobject|droprelloc|lift|lifttype|waitforgump|gumpresponse|gumpclose|menu|menuresponse|waitformenu|promptresponse|waitforprompt|hotkey|say|msg|overhead|sysmsg|wait|pause|waitforstat|setability|setlasttarget|lasttarget|setvar|skill|useskill|walk|script|useonce|organizer|organize|org|restock|scav|scavenger|potion|clearsysmsg|clearjournal|whisper|yell|guild|alliance|emote|waitforsysmsg|wfsysmsg|clearall|virtue|rename|setskill|ignore|clearignore|poplist|pushlist|removelist|createlist|clearlist|settimer|removetimer|createtimer|settimer|removetimer|getlabel|unsetvar)\b",
+                    @"\b(attack|cast|dress|undress|dressconfig|target|targettype|targetloc|targetrelloc|dress|drop|waitfortarget|wft|dclick|dclicktype|dclickvar|usetype|useobject|droprelloc|lift|lifttype|waitforgump|gumpresponse|gumpclose|menu|menuresponse|waitformenu|promptresponse|waitforprompt|hotkey|say|msg|overhead|sysmsg|wait|pause|waitforstat|setability|setlasttarget|lasttarget|setvar|skill|useskill|walk|script|useonce|organizer|organize|org|restock|scav|scavenger|potion|clearsysmsg|clearjournal|whisper|yell|guild|alliance|emote|waitforsysmsg|wfsysmsg|clearall|virtue|rename|setskill|ignore|clearignore|poplist|pushlist|removelist|createlist|clearlist|atlist|settimer|removetimer|createtimer|settimer|removetimer|getlabel|unsetvar)\b",
                     RegexCompiledOption);
 
              RazorLayerRegex =

--- a/Razor/Scripts/Engine/Interpreter.cs
+++ b/Razor/Scripts/Engine/Interpreter.cs
@@ -1358,16 +1358,18 @@ namespace Assistant.Scripts.Engine
             return _lists[name].Remove(arg);
         }
 
-        public static bool PopList(string name, bool front)
+        public static bool PopList(string name, bool front, out Variable removedVar)
         {
             if (!_lists.ContainsKey(name))
                 throw new RunTimeError("List does not exist");
 
-            var idx = front ? 0 : _lists[name].Count - 1;
+            var list = _lists[name];
+            var idx = front ? 0 : list.Count - 1;
 
-            _lists[name].RemoveAt(idx);
+            removedVar = list[idx];
+            list.RemoveAt(idx);
 
-            return _lists[name].Count > 0;
+            return list.Count > 0;
         }
 
         public static Variable GetListValue(string name, int idx)

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -1,4 +1,4 @@
-#region license
+﻿#region license
 
 // Razor: An Ultima Online Assistant
 // Copyright (C) 2021 Razor Development Community on GitHub <https://github.com/markdwags/Razor>
@@ -36,7 +36,7 @@ namespace Assistant.Scripts
         {
             // Lists
             Interpreter.RegisterExpressionHandler("poplist", PopListExp);
-            // Interpreter.RegisterCommandHandler("poplist", PopList);
+            Interpreter.RegisterCommandHandler("poplist", PopList);
             Interpreter.RegisterCommandHandler("pushlist", PushList);
             Interpreter.RegisterCommandHandler("removelist", RemoveList);
             Interpreter.RegisterCommandHandler("createlist", CreateList);
@@ -130,21 +130,24 @@ namespace Assistant.Scripts
             if (args[1].AsString() == "front")
             {
                 if (force)
-                    while (Interpreter.PopList(args[0].AsString(), true)) { }
+                    while (Interpreter.PopList(args[0].AsString(), true, out _))
+                    { }
                 else
-                    Interpreter.PopList(args[0].AsString(), true);
+                    Interpreter.PopList(args[0].AsString(), true, out _);
             }
             else if (args[1].AsString() == "back")
             {
                 if (force)
-                    while (Interpreter.PopList(args[0].AsString(), false)) { }
+                    while (Interpreter.PopList(args[0].AsString(), false, out _))
+                    { }
                 else
-                    Interpreter.PopList(args[0].AsString(), false);
+                    Interpreter.PopList(args[0].AsString(), false, out _);
             }
             else
             {
                 if (force)
-                    while (Interpreter.PopList(args[0].AsString(), args[1])) { }
+                    while (Interpreter.PopList(args[0].AsString(), args[1]))
+                    { }
                 else
                     Interpreter.PopList(args[0].AsString(), args[1]);
             }
@@ -205,8 +208,13 @@ namespace Assistant.Scripts
                 throw new RunTimeError("Usage: atlist ('list name') (index (starts with 0))");
 
             var value = Interpreter.GetListValue(args[0].AsString(), args[1].AsInt());
+            var serial = value?.AsSerial();
 
-            return value?.AsUInt() ?? Serial.Zero;
+            // We need to check for max value because razor will look up the list name as a global alias and return max when finding none
+            if (!serial.HasValue || serial == uint.MaxValue)
+                return Serial.Zero;
+
+            return serial.Value;
         }
 
         private static bool SetTimer(string command, Variable[] args, bool quiet, bool force)

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -40,6 +40,7 @@ namespace Assistant.Scripts
             Interpreter.RegisterCommandHandler("removelist", RemoveList);
             Interpreter.RegisterCommandHandler("createlist", CreateList);
             Interpreter.RegisterCommandHandler("clearlist", ClearList);
+            Interpreter.RegisterExpressionHandler("atlist", AtList);
 
             // Timers
             Interpreter.RegisterCommandHandler("settimer", SetTimer);
@@ -163,6 +164,16 @@ namespace Assistant.Scripts
             Interpreter.ClearList(args[0].AsString());
 
             return true;
+        }
+        
+        private static uint AtList(string command, Variable[] args, bool quiet, bool force)
+        {
+            if (args.Length != 2)
+                throw new RunTimeError("Usage: atlist ('list name') (index (starts with 0))");
+
+            var value = Interpreter.GetListValue(args[0].AsString(), args[1].AsInt());
+
+            return value?.AsUInt() ?? Serial.Zero;
         }
 
         private static bool SetTimer(string command, Variable[] args, bool quiet, bool force)

--- a/Razor/Scripts/Outlands.cs
+++ b/Razor/Scripts/Outlands.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Razor: An Ultima Online Assistant
 // Copyright (C) 2021 Razor Development Community on GitHub <https://github.com/markdwags/Razor>
@@ -35,7 +35,8 @@ namespace Assistant.Scripts
         public static void Register()
         {
             // Lists
-            Interpreter.RegisterCommandHandler("poplist", PopList);
+            Interpreter.RegisterExpressionHandler("poplist", PopListExp);
+            // Interpreter.RegisterCommandHandler("poplist", PopList);
             Interpreter.RegisterCommandHandler("pushlist", PushList);
             Interpreter.RegisterCommandHandler("removelist", RemoveList);
             Interpreter.RegisterCommandHandler("createlist", CreateList);
@@ -87,6 +88,38 @@ namespace Assistant.Scripts
             // Gump
             Interpreter.RegisterExpressionHandler("gumpexists", GumpExists);
             Interpreter.RegisterExpressionHandler("ingump", InGump);
+        }
+
+        private static uint PopListExp(string command, Variable[] args, bool quiet, bool force)
+        {
+            if (args.Length != 2)
+                throw new RunTimeError("Usage: poplist ('list name') ('element value'/'front'/'back')");
+
+            var listName = args[0].AsString();
+            var frontBackOrElementVar = args[1];
+            var isFrontOrBack = frontBackOrElementVar.AsString() == "front" || frontBackOrElementVar.AsString() == "back";
+
+            if (isFrontOrBack)
+            {
+                var isFront = frontBackOrElementVar.AsString() == "front";
+                if (force)
+                {
+                    while (Interpreter.PopList(listName, isFront, out _)) { }
+                    return Serial.Zero;
+                }
+
+                Interpreter.PopList(listName, isFront, out var popped);
+                return popped.AsSerial();
+            }
+
+            if (force)
+            {
+                while (Interpreter.PopList(listName, frontBackOrElementVar)) { }
+                return Serial.Zero;
+            }
+
+            Interpreter.PopList(listName, frontBackOrElementVar);
+            return frontBackOrElementVar.AsSerial();
         }
 
         private static bool PopList(string command, Variable[] args, bool quiet, bool force)

--- a/Razor/Scripts/ScriptManager.cs
+++ b/Razor/Scripts/ScriptManager.cs
@@ -567,7 +567,7 @@ namespace Assistant.Scripts
                     "setvar", "skill", "sysmsg", "target", "targettype", "targetrelloc", "undress", "useonce", "walk",
                     "wait", "pause", "waitforgump", "waitformenu", "waitforprompt", "waitfortarget", "clearsysmsg", "clearjournal",
                     "waitforsysmsg", "clearhands", "clearall", "virtue", "random",
-                    "warmode", "getlabel", "createlist", "clearlist", "removelist", "pushlist", "poplist", "createtimer", "removetimer", "settimer",
+                    "warmode", "getlabel", "createlist", "clearlist", "atlist", "removelist", "pushlist", "poplist", "createtimer", "removetimer", "settimer",
                     "unsetvar", "ignore", "clearignore", "rename", "setskill", "noto", "ingump", "gumpexists", "dead", "invul", "paralyzed",
                     "counttype", "diffmana", "diffstam", "diffhits", "diffweight", "maxweight", "targetexists", "find", "findlayer", "name",
                     "followers", "hue", "timerexists", "timer",
@@ -899,6 +899,12 @@ namespace Assistant.Scripts
                 "Clear an existing list. The list still exists after this operation.",
                 "clearlist mylist\n");
             descriptionCommands.Add("clearlist", tooltip);
+            
+            tooltip = new ToolTipDescriptions("atlist",
+                new[] { "atlist ('list name') (index (starts with 0))" }, "the serial at the specified index in the list",
+                "Retrieve a list entry at the specified index. Only works if the entry is a serial!",
+                "if atlist mylist 0 as firstListEntry\n\t...\nendif\n");
+            descriptionCommands.Add("atlist", tooltip);
 
             tooltip = new ToolTipDescriptions("removelist",
                 new[] { "removelist ('list name')" }, "N/A",


### PR DESCRIPTION
### atlist expression

Atlist retrieves a list item of the specified index. Will return 0 if the index is out of bounds or the retrieved item could not be converted into a serial.

`Usage: atlist ('list name') (index (starts with 0))`

```
createlist testlist
clearlist testlist
pushlist testlist 0x1
pushlist testlist 0x2
pushlist testlist 0x3

if atlist testlist 2 as entry
    overhead firstentry
else
    overhead "index out of bounds or list item retrievend was no serial"
endif
```

### poplist expression

Implemented a second version of poplist as an expression so the item popped can be retrieved via the `as` operator. Works alongside the normal poplist command.

```
if poplist testlist back as popped
    overhead popped
endif
```